### PR TITLE
fix(ios): add workaround to avoid Xcode caching local pods

### DIFF
--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -1,6 +1,11 @@
 platform :ios, '11.0'
 use_frameworks!
 
+# workaround to avoid Xcode caching of Pods that requires
+# Product -> Clean Build Folder after new Cordova plugins installed
+# Requires CocoaPods 1.6 or newer
+install! 'cocoapods', :disable_input_output_paths => true
+
 def capacitor_pods
   # Automatic Capacitor Pod dependencies, do not delete
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'


### PR DESCRIPTION
The app was created before Capacitor was final and it's missing that workaround that prevents Xcode caching local pods

https://github.com/ionic-team/capacitor/blob/master/ios-template/App/Podfile#L4-L7